### PR TITLE
update: typescript-eslint/camelcase rule deprecated

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -51,7 +51,7 @@
     "no-shadow": "off",
     "no-unused-expressions": ["warn"],
     "@typescript-eslint/no-shadow": ["error"],
-    "@typescript-eslint/camelcase": "off",
+    "@typescript-eslint/naming-convention": "off",
     "@typescript-eslint/unbound-method": "off",
     "@typescript-eslint/no-non-null-assertion": "off",
     "@typescript-eslint/no-unsafe-member-access": "off",


### PR DESCRIPTION
# 개요

eslint 설정 중에 `@typescript-eslint/camelcase` 규칙 문서를 보니 해당 규칙이 deprecated 되었고, `@typescript-eslint/naming-convention` 으로 대체해서 사용하라고 안내되어 있어 수정하였습니다. 

#  관련 문서

>  `@typescript-eslint/camelcase` 
>https://github.com/typescript-eslint/typescript-eslint/blob/main/packages/eslint-plugin/docs/rules/camelcase.md

>  `@typescript-eslint/naming-convention`
>https://github.com/typescript-eslint/typescript-eslint/blob/main/packages/eslint-plugin/docs/rules/naming-convention.md
